### PR TITLE
Add uniformsNeedUpdate to base Material class

### DIFF
--- a/src/materials/Material.js
+++ b/src/materials/Material.js
@@ -72,6 +72,7 @@ class Material extends EventDispatcher {
 		this.userData = {};
 
 		this.version = 0;
+		this.uniformsNeedUpdate = false;
 
 		this._alphaTest = 0;
 

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -46,7 +46,6 @@ class ShaderMaterial extends Material {
 		};
 
 		this.index0AttributeName = undefined;
-		this.uniformsNeedUpdate = false;
 
 		this.glslVersion = null;
 

--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -1766,7 +1766,7 @@ function WebGLRenderer( parameters = {} ) {
 
 		}
 
-		if ( refreshMaterial ) {
+		if ( refreshMaterial || material.uniformsNeedUpdate ) {
 
 			p_uniforms.setValue( _gl, 'toneMappingExposure', _this.toneMappingExposure );
 
@@ -1796,13 +1796,6 @@ function WebGLRenderer( parameters = {} ) {
 			materials.refreshMaterialUniforms( m_uniforms, material, _pixelRatio, _height, _transmissionRenderTarget );
 
 			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
-
-		}
-
-		if ( material.isShaderMaterial && material.uniformsNeedUpdate === true ) {
-
-			WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
-			material.uniformsNeedUpdate = false;
 
 		}
 

--- a/src/renderers/webgl/WebGLMaterials.js
+++ b/src/renderers/webgl/WebGLMaterials.js
@@ -91,11 +91,9 @@ function WebGLMaterials( renderer, properties ) {
 			uniforms.color.value.copy( material.color );
 			uniforms.opacity.value = material.opacity;
 
-		} else if ( material.isShaderMaterial ) {
-
-			material.uniformsNeedUpdate = false; // #15581
-
 		}
+
+		material.uniformsNeedUpdate = false; // #15581
 
 	}
 


### PR DESCRIPTION
`uniformsNeedUpdate` is available on ShaderMaterials but not on other materials. In order to update per-mesh uniforms in an `onBeforeRender` callback, it is useful to be able to set `uniformsNeedUpdate` to apply any updated uniforms.